### PR TITLE
Add option to set prefix for id

### DIFF
--- a/src/dot.py
+++ b/src/dot.py
@@ -324,10 +324,13 @@ class Node:
         o.write("    \"%s\"\n" % self.getLabel(conf).encode(latinenc, errors="ignore"))
         o.write("  ]\n")
 
+    def getPrefixedId(self, prefix, id=None):
+        return "%s-%s" %(prefix, self.id if id is None else id)
+
     def exportGraphml(self, doc, parent, conf):        
         """ export the node in Graphml format and append it to the parent XML node """
         node = doc.createElement(u'node')
-        node.setAttribute(u'id',u'n%d' % self.id)
+        node.setAttribute(u'id',u'n%s' % self.getPrefixedId(conf.PrefixForId))
         
         data0 = doc.createElement(u'data')
         data0.setAttribute(u'key', u'd0')
@@ -418,6 +421,9 @@ class Edge:
         self.dest = ""
         self.attribs = {}
 
+    def getPrefixedId(self, prefix, id=None):
+        return "%s-%s" %(prefix, self.id if id is None else id)
+
     def initFromString(self, line):
         """ extract edge info from the given text line """
         spos = findUnquoted(line, '[')
@@ -506,9 +512,9 @@ class Edge:
     def exportGraphml(self, doc, parent, nodes, conf):
         """ export the edge in Graphml format and append it to the parent XML node """
         edge = doc.createElement(u'edge')
-        edge.setAttribute(u'id',u'e%d' % self.id)
-        edge.setAttribute(u'source',u'n%d' % nodes[self.src].id)
-        edge.setAttribute(u'target',u'n%d' % nodes[self.dest].id)
+        edge.setAttribute(u'id',u'e%s' % self.getPrefixedId(conf.PrefixForId))
+        edge.setAttribute(u'source',u'n%s' % self.getPrefixedId(prefix=conf.PrefixForId, id=nodes[self.src].id))
+        edge.setAttribute(u'target',u'n%s' % self.getPrefixedId(prefix=conf.PrefixForId, id=nodes[self.dest].id))
         
         data2 = doc.createElement(u'data')
         data2.setAttribute(u'key', u'd2')

--- a/src/dottoxml.py
+++ b/src/dottoxml.py
@@ -245,7 +245,7 @@ def main():
             # Process edge
             e = dot.Edge()
             e.initFromString(l)
-            e.id = "%s_%s" % (options.PrefixForId, eid)
+            e.id = eid
             eid += 1
             if default_edge:
                 e.complementAttributes(default_edge)
@@ -291,7 +291,7 @@ def main():
         if not nodes.has_key(e.src):
             n = dot.Node()
             n.label = e.src
-            n.id = "%s_%s" % (options.PrefixForId, nid)
+            n.id = nid
             nid += 1
             nodes[e.src] = n
         if not nodes.has_key(e.dest):

--- a/src/dottoxml.py
+++ b/src/dottoxml.py
@@ -186,6 +186,9 @@ def main():
     parser.add_option('--oenc', '--output-encoding',
                       action='store', dest='OutputEncoding', default='', metavar='ENCODING',
                       help='override encoding for text output files [default : locale setting]')
+    parser.add_option('--pfd', '--prefix-for-id',
+                      action='store', dest='PrefixForId', default='',
+                      help='Prepend prefix into node and edge id [default : empty]')
 
     options, args = parser.parse_args()
     
@@ -242,7 +245,7 @@ def main():
             # Process edge
             e = dot.Edge()
             e.initFromString(l)
-            e.id = eid
+            e.id = "%s_%s" % (options.PrefixForId, eid)
             eid += 1
             if default_edge:
                 e.complementAttributes(default_edge)
@@ -288,7 +291,7 @@ def main():
         if not nodes.has_key(e.src):
             n = dot.Node()
             n.label = e.src
-            n.id = nid
+            n.id = "%s_%s" % (options.PrefixForId, nid)
             nid += 1
             nodes[e.src] = n
         if not nodes.has_key(e.dest):


### PR DESCRIPTION
### Background:
I'm using the script to convert multiple dot files to graphml and use them in one graphwalker test. During graphml/model checking in Graphwalker, node/edge with duplicate names are detected.

### Proposed change:
Add option to set prefix for id.
eg: `pipenv run python ~/Playground/dottoxml/src/dottoxml.py --pfd ModelA model_a.graphml`

It will transform id for edge and nodes (during conversion to graphml) into:
`nModelA-1` instead of `n1`
`eModelA-1` instead of `e1`